### PR TITLE
Add allow queries JSON to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ COPY server/src ./server/src
 COPY server/pom.xml ./server/
 COPY plugins/src ./plugins/src
 COPY plugins/pom.xml ./plugins/
+COPY resources/hapi_page_url_allowed_queries.json resources/hapi_page_url_allowed_queries.json
 COPY license-header.txt .
 COPY pom.xml .
 RUN mvn spotless:check


### PR DESCRIPTION
This PR let's the following command work:

```
 ALLOWED_QUERIES_FILE=resources/hapi_page_url_allowed_queries.json  RUN_MODE="DEV"  docker-compose -f docker/hapi-proxy-compose.yaml                up --force-recreate --remove-orphans -d --quiet-pull --wait
```

without the file being added to the Dockerfile, the binary throws an error complaining that the file does not exist