### PR TITLE
update image ref to open repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ repository, can be selected by either of:
   export ACCESS_CHECKER=list
   export ACCESS_CHECKER=patient
   ```
-  
-- **AllowedQueriesChecker**: There are URL requests that the server can allow 
+
+- **AllowedQueriesChecker**: There are URL requests that the server can allow
    without going through an access checker. [`AllowedQueriesChecker`](https://github.com/google/fhir-access-proxy/blob/main/server/src/main/java/com/google/fhir/proxy/AllowedQueriesChecker.java)
    is a special `AccessChecker` that compares the incoming request with a configured set of
    allowed-queries. The intended use of this checker is to override all other
@@ -122,7 +122,7 @@ The proxy is also available as a [docker image](Dockerfile):
 ```shell
 $ docker run -p 8081:8080 -e TOKEN_ISSUER=[token_issuer_url] \
   -e PROXY_TO=[fhir_server_url] -e ACCESS_CHECKER=list \
-  gcr.io/second-scion-309318/fhir-proxy:latest
+  us-docker.pkg.dev/fhir-proxy-build/stable/fhir-access-proxy:latest
 ```
 
 Note if the `TOKEN_ISSUER` is on the `localhost` you need  to bypass proxy's

--- a/build.sh
+++ b/build.sh
@@ -28,4 +28,4 @@ set -e
 export BUILD_ID=${KOKORO_BUILD_ID:-local}
 gcloud auth configure-docker
 ./e2e-test/e2e.sh
-docker push us-docker.pkg.dev/fhir-proxy-build/kokoro/fhir-access-proxy:${BUILD_ID}
+docker push us-docker.pkg.dev/fhir-proxy-build/stable/fhir-access-proxy:${BUILD_ID}

--- a/build.sh
+++ b/build.sh
@@ -28,4 +28,4 @@ set -e
 export BUILD_ID=${KOKORO_BUILD_ID:-local}
 gcloud auth configure-docker
 ./e2e-test/e2e.sh
-docker push us-docker.pkg.dev/fhir-proxy-build/stable/fhir-access-proxy:${BUILD_ID}
+docker push us-docker.pkg.dev/fhir-proxy-build/kokoro/fhir-access-proxy:${BUILD_ID}

--- a/build.sh
+++ b/build.sh
@@ -28,4 +28,4 @@ set -e
 export BUILD_ID=${KOKORO_BUILD_ID:-local}
 gcloud auth configure-docker
 ./e2e-test/e2e.sh
-docker push gcr.io/second-scion-309318/fhir-proxy:${BUILD_ID}
+docker push us-docker.pkg.dev/fhir-proxy-build/stable/fhir-access-proxy:${BUILD_ID}

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,7 +8,7 @@ and a single-patient based SMART-on-FHIR app (in two separate realms).
 
 ## Pre-loaded HAPI Server
 
-The [gcr.io/second-scion-309318/synthetic-data:latest](https://console.cloud.google.com/gcr/images/fhir-sdk/global/synthetic-data)
+The [us-docker.pkg.dev/fhir-proxy-build/stable/hapi-synthea:latest](https://console.cloud.google.com/gcr/images/fhir-sdk/global/synthetic-data)
 image is based on the HAPI FHIR [image](https://hub.docker.com/r/hapiproject/hapi) with the
 `1K Sample Synthetic Patient Records, FHIR R4` dataset from [Synthea](https://synthea.mitre.org/downloads) stored in the
 container itself. To load this dataset into the HAPI FHIR image, do the following:
@@ -77,10 +77,10 @@ following to upload the list into the server
 
 6. Commit the Docker container. This saves its state into a new image
    ```
-    docker commit hapi_fhir gcr.io/second-scion-309318/synthetic-data:latest
+    docker commit hapi_fhir us-docker.pkg.dev/fhir-proxy-build/stable/hapi-synthea:latest
     ```
 
 7. Push the image
    ```
-    docker push gcr.io/second-scion-309318/synthetic-data:latest
+    docker push us-docker.pkg.dev/fhir-proxy-build/stable/hapi-synthea:latest
    ```

--- a/docker/hapi-proxy-compose.yaml
+++ b/docker/hapi-proxy-compose.yaml
@@ -35,7 +35,7 @@ version: "3.0"
 
 services:
   fhir-proxy:
-    image: gcr.io/second-scion-309318/fhir-proxy:${BUILD_ID:-latest}
+    image: us-docker.pkg.dev/fhir-proxy-build/stable/fhir-access-proxy:${BUILD_ID:-latest}
     environment:
     - TOKEN_ISSUER
     - PROXY_TO
@@ -54,6 +54,6 @@ services:
       timeout: 10s
 
   hapi-server:
-    image: gcr.io/second-scion-309318/synthetic-data:latest
+    image: us-docker.pkg.dev/fhir-proxy-build/stable/hapi-synthea:latest
     ports:
     - "8099:8080"

--- a/docker/keycloak/README.md
+++ b/docker/keycloak/README.md
@@ -19,7 +19,7 @@ is intended for a SMART on FHIR app with patient scopes.
 - The `alvearie/keycloak-config:latest` docker image to configure a SMART
 enabled realm. This is useful for the `patient` access-checker.
 
-- The `gcr.io/second-scion-309318/keycloak-config:latest` docker image to configure a realm
+- The `us-docker.pkg.dev/fhir-proxy-build/stable/keycloak-config:latest` docker image to configure a realm
 for the `list` access-checker.
 
 You can change the configuration parameters by changing environment variables

--- a/docker/keycloak/config-compose.yaml
+++ b/docker/keycloak/config-compose.yaml
@@ -78,7 +78,7 @@ services:
     - KEYCLOAK_REALM=${SMART_REALM:-dummy-smart}
 
   proxy-config:
-    image: gcr.io/second-scion-309318/keycloak-config:latest
+    image: us-docker.pkg.dev/fhir-proxy-build/stable/keycloak-config:latest
     depends_on:
       smart-config:
         condition: service_completed_successfully

--- a/e2e-test/e2e.sh
+++ b/e2e-test/e2e.sh
@@ -21,7 +21,7 @@ set -e
 export BUILD_ID=${KOKORO_BUILD_ID:-local}
 
 function setup() {
-  docker build -t gcr.io/second-scion-309318/fhir-proxy:${BUILD_ID} .
+  docker build -t us-docker.pkg.dev/fhir-proxy-build/stable/fhir-access-proxy:${BUILD_ID} .
   docker-compose -f docker/keycloak/config-compose.yaml \
                  up --force-recreate --remove-orphans -d --quiet-pull
   docker-compose -f docker/hapi-proxy-compose.yaml \


### PR DESCRIPTION
TESTED:
* Cleared local docker images and ran `docker-compose` commands that worked
* Visited repo [url](https://console.cloud.google.com/artifacts/docker/fhir-proxy-build/us/stable?project=fhir-proxy-build) from non-Google email and the page opened