### PR TITLE
Return 403 when access is denied

### DIFF
--- a/server/src/main/java/com/google/fhir/proxy/BearerAuthorizationInterceptor.java
+++ b/server/src/main/java/com/google/fhir/proxy/BearerAuthorizationInterceptor.java
@@ -24,6 +24,7 @@ import ca.uhn.fhir.rest.api.server.IRestfulResponse;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
+import ca.uhn.fhir.rest.server.exceptions.ForbiddenOperationException;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
@@ -244,7 +245,7 @@ public class BearerAuthorizationInterceptor {
           String.format(
               "User is not authorized to %s %s",
               requestDetails.getRequestType(), requestDetails.getCompleteUrl()),
-          AuthenticationException.class);
+          ForbiddenOperationException.class);
     }
     return outcome;
   }

--- a/server/src/test/java/com/google/fhir/proxy/BearerAuthorizationInterceptorTest.java
+++ b/server/src/test/java/com/google/fhir/proxy/BearerAuthorizationInterceptorTest.java
@@ -117,7 +117,7 @@ public class BearerAuthorizationInterceptorTest {
     return null;
   }
 
-  private BearerAuthorizationInterceptor createTestInstance(boolean returnedCheck)
+  private BearerAuthorizationInterceptor createTestInstance(boolean isAccessGranted)
       throws IOException {
     return new BearerAuthorizationInterceptor(
         fhirClientMock,
@@ -129,7 +129,7 @@ public class BearerAuthorizationInterceptorTest {
             new AccessChecker() {
               @Override
               public AccessDecision checkAccess(RequestDetailsReader requestDetails) {
-                return new NoOpAccessDecision(returnedCheck);
+                return new NoOpAccessDecision(isAccessGranted);
               }
             },
         new AllowedQueriesChecker(null));

--- a/server/src/test/java/com/google/fhir/proxy/BearerAuthorizationInterceptorTest.java
+++ b/server/src/test/java/com/google/fhir/proxy/BearerAuthorizationInterceptorTest.java
@@ -29,6 +29,7 @@ import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.server.IRestfulResponse;
 import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
+import ca.uhn.fhir.rest.server.exceptions.ForbiddenOperationException;
 import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTCreator;
@@ -37,6 +38,10 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
+import com.google.fhir.proxy.interfaces.AccessChecker;
+import com.google.fhir.proxy.interfaces.AccessDecision;
+import com.google.fhir.proxy.interfaces.NoOpAccessDecision;
+import com.google.fhir.proxy.interfaces.RequestDetailsReader;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -112,6 +117,24 @@ public class BearerAuthorizationInterceptorTest {
     return null;
   }
 
+  private BearerAuthorizationInterceptor createTestInstance(boolean returnedCheck)
+      throws IOException {
+    return new BearerAuthorizationInterceptor(
+        fhirClientMock,
+        TOKEN_ISSUER,
+        "test",
+        serverMock,
+        httpUtilMock,
+        (jwt, httpFhirClient, fhirContext, patientFinder) ->
+            new AccessChecker() {
+              @Override
+              public AccessDecision checkAccess(RequestDetailsReader requestDetails) {
+                return new NoOpAccessDecision(returnedCheck);
+              }
+            },
+        new AllowedQueriesChecker(null));
+  }
+
   @Before
   public void setUp() throws IOException {
     String publicKeyBase64 = generateKeyPairAndEncode();
@@ -126,15 +149,7 @@ public class BearerAuthorizationInterceptorTest {
     when(httpUtilMock.fetchWellKnownConfig(anyString(), anyString())).thenReturn(testIdpConfig);
     when(fhirClientMock.handleRequest(requestMock)).thenReturn(fhirResponseMock);
     when(fhirClientMock.getBaseUrl()).thenReturn(FHIR_STORE);
-    testInstance =
-        new BearerAuthorizationInterceptor(
-            fhirClientMock,
-            TOKEN_ISSUER,
-            "test",
-            serverMock,
-            httpUtilMock,
-            new PermissiveAccessChecker.Factory(),
-            new AllowedQueriesChecker(null));
+    testInstance = createTestInstance(true);
   }
 
   private String signJwt(JWTCreator.Builder jwtBuilder) {
@@ -293,5 +308,13 @@ public class BearerAuthorizationInterceptorTest {
     assertThat(
         capability.getRest().get(0).getSecurity().getService().get(0).getCoding().get(0).getCode(),
         equalTo("OAuth"));
+  }
+
+  @Test(expected = ForbiddenOperationException.class)
+  public void deniedRequest() throws IOException {
+    // Changing the access-checker to something that always denies.
+    testInstance = createTestInstance(false);
+    authorizeRequestCommonSetUp("never returned response");
+    testInstance.authorizeRequest(requestMock);
   }
 }


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->
## Description of what I changed
Fixes #16 

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test
<!-- There are different scenarios for using the tools in this repo; please 
  help your reviewers by describing how you have e2e tested your change. -->
TESTED:

Manually ran the proxy and tested that 403 is returned instead of 401, when access is denied.

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.
- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).
- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.