### PR TITLE
Fix for e2e failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ COPY license-header.txt .
 COPY pom.xml .
 
 RUN mvn spotless:check
-RUN mvn --batch-mode package -Pstandalone-app
+# Updating license will fail in e2e and there is no point doing it here anyways.
+RUN mvn --batch-mode package -Pstandalone-app -Dlicense.skip=true
 
 
 # Image for FHIR Access Proxy binary with configuration knobs as environment vars.

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -67,6 +67,7 @@
           <plugin>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-maven-plugin</artifactId>
+            <version>${spring-boot.version}</version>
             <executions>
               <execution>
                 <id>repackage</id>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <root.basedir>${project.basedir}</root.basedir>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <spring-boot.version>2.6.6</spring-boot.version>
+    <spring-boot.version>2.7.5</spring-boot.version>
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
   </properties>
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -34,7 +34,7 @@
   <dependencyManagement>
     <dependencies>
       <!-- Instead of using spring-boot-starter-parent as POM parent we add
-      pieces needed from it; alse see:
+      pieces needed from it; also see:
       https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#using.import
       -->
       <dependency>
@@ -160,6 +160,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
         <executions>
           <execution>
             <id>repackage</id>


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->

## Description of what I changed

The main fix is specifying the version for spring-boot-maven-plugin but I also updated the Spring version
and fixed other minor issues too.

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Just relied on the continuous tests.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.
- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).
- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.