### PR TITLE
Defined Request/response headers that proxy to pass to/from a FHIR server

### DIFF
--- a/server/src/test/java/com/google/fhir/proxy/HttpFhirClientTest.java
+++ b/server/src/test/java/com/google/fhir/proxy/HttpFhirClientTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.fhir.proxy;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+
+import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.message.BasicHeader;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HttpFhirClientTest {
+
+  @Spy private HttpFhirClient fhirClient;
+
+  @Mock private ServletRequestDetails requestMock;
+
+  @Mock private HttpResponse httpResponse;
+
+  @Test
+  public void copyRequiredHeaders_passAllowedHeaders_addsToRequest() {
+    Map<String, List<String>> headers = new HashMap<>();
+    String allowedRequestHeader = "etag";
+    List<String> headerValues = List.of("test-val-1", "test-val-2");
+    headers.put(allowedRequestHeader, headerValues);
+    when(requestMock.getHeaders()).thenReturn(headers);
+    RequestBuilder requestBuilder = RequestBuilder.create("POST");
+
+    fhirClient.copyRequiredHeaders(requestMock, requestBuilder);
+
+    assertThat(
+        Arrays.stream(requestBuilder.getHeaders(allowedRequestHeader))
+            .map(header -> (BasicHeader) header)
+            .map(BasicHeader::getValue)
+            .toArray(),
+        arrayContainingInAnyOrder("test-val-1", "test-val-2"));
+  }
+
+  @Test
+  public void copyRequiredHeaders_passNotAllowedHeaders_emptyRequestHeaders() {
+    Map<String, List<String>> headers = new HashMap<>();
+    String unsupportedHeader = "unsupported-header";
+    headers.put(unsupportedHeader, List.of("test-val-1", "test-val-2"));
+    when(requestMock.getHeaders()).thenReturn(headers);
+    RequestBuilder requestBuilder = RequestBuilder.create("POST");
+
+    fhirClient.copyRequiredHeaders(requestMock, requestBuilder);
+
+    assertThat(requestBuilder.getHeaders(unsupportedHeader), nullValue());
+  }
+
+  @Test
+  public void responseHeadersToKeep_addAllowedHeaders() {
+    String allowedRequestHeader = "etag";
+    Header[] headers = {
+      new BasicHeader(allowedRequestHeader, "test-val-1"),
+      new BasicHeader(allowedRequestHeader, "test-val-2")
+    };
+    when(httpResponse.getAllHeaders()).thenReturn(headers);
+
+    List<Header> responseHeaders = fhirClient.responseHeadersToKeep(httpResponse);
+
+    assertThat(responseHeaders, containsInAnyOrder(headers));
+  }
+
+  @Test
+  public void responseHeadersToKeep_passNotAllowedHeaders_emptyRequestHeaders() {
+    String unsupportedHeader = "unsupportedHeader";
+    Header[] headers = {
+      new BasicHeader(unsupportedHeader, "test-val-1"),
+      new BasicHeader(unsupportedHeader, "test-val-2")
+    };
+    when(httpResponse.getAllHeaders()).thenReturn(headers);
+
+    List<Header> responseHeaders = fhirClient.responseHeadersToKeep(httpResponse);
+
+    assertThat(responseHeaders, empty());
+  }
+}


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->

## Description of what I changed
Added support for headers defined in https://www.hl7.org/fhir/http.html#ops and https://www.hl7.org/fhir/async.html

If there are multiple values for the same header then only 1 was being sent to FHIR server. Caught this issue in test cases.

Fixes https://github.com/google/fhir-access-proxy/issues/44
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:
Ran the server locally to verify the request and response headers. Allowed response headers are now being returned in the curl request. Ran the server in debug mode to verify if the Allowed request headers are passed to FHIR if caller is sending those headers.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the
      [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review
  [Java](https://google.github.io/styleguide/javaguide.html) and
  [Python](https://google.github.io/styleguide/pyguide.html) style guides. Note,
  when in conflict, OpenMRS style guide overrules.

- [x] My IDE is configured to follow the Google
      [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? ->
  [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing
      code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and
      added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
