### PR TITLE
Relay FHIR server errors to the client as it is

### DIFF
--- a/server/src/main/java/com/google/fhir/proxy/BearerAuthorizationInterceptor.java
+++ b/server/src/main/java/com/google/fhir/proxy/BearerAuthorizationInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Google LLC
+ * Copyright 2021-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -268,21 +268,21 @@ public class BearerAuthorizationInterceptor {
     logger.debug("Authorized request path " + requestPath);
     try {
       HttpResponse response = fhirClient.handleRequest(servletDetails);
-      // TODO pass along the response to the client in case of errors (b/211233113).
-      HttpUtil.validateResponseEntityOrFail(response, requestPath);
       // TODO communicate post-processing failures to the client (b/211243404).
       String content = null;
-      try {
-        // For post-processing rationale/example see b/207589782#comment3.
-        content = outcome.postProcess(response);
-      } catch (Exception e) {
-        // Note this is after a successful fetch/update of the FHIR store. That success must be
-        // passed to the client even if the access related post-processing fails.
-        logger.error(
-            "Exception in access related post-processing for {} {}",
-            requestDetails.getRequestType(),
-            requestDetails.getRequestPath(),
-            e);
+      if (HttpUtil.isResponseEntityValid(response)) {
+        try {
+          // For post-processing rationale/example see b/207589782#comment3.
+          content = outcome.postProcess(response);
+        } catch (Exception e) {
+          // Note this is after a successful fetch/update of the FHIR store. That success must be
+          // passed to the client even if the access related post-processing fails.
+          logger.error(
+              "Exception in access related post-processing for {} {}",
+              requestDetails.getRequestType(),
+              requestDetails.getRequestPath(),
+              e);
+        }
       }
       HttpEntity entity = response.getEntity();
       logger.debug(String.format("The response for %s is %s ", requestPath, response));

--- a/server/src/main/java/com/google/fhir/proxy/BearerAuthorizationInterceptor.java
+++ b/server/src/main/java/com/google/fhir/proxy/BearerAuthorizationInterceptor.java
@@ -268,10 +268,12 @@ public class BearerAuthorizationInterceptor {
     logger.debug("Authorized request path " + requestPath);
     try {
       HttpResponse response = fhirClient.handleRequest(servletDetails);
+      HttpUtil.validateResponseEntityExistsOrFail(response, requestPath);
       // TODO communicate post-processing failures to the client; see:
       //   https://github.com/google/fhir-access-proxy/issues/66
+
       String content = null;
-      if (HttpUtil.isResponseEntityValid(response)) {
+      if (HttpUtil.isResponseValid(response)) {
         try {
           // For post-processing rationale/example see b/207589782#comment3.
           content = outcome.postProcess(response);

--- a/server/src/main/java/com/google/fhir/proxy/HttpUtil.java
+++ b/server/src/main/java/com/google/fhir/proxy/HttpUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Google LLC
+ * Copyright 2021-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,16 @@ public class HttpUtil {
 
   public static boolean isResponseValid(HttpResponse response) {
     return isResponseValidInternal(response, false);
+  }
+
+  public static void validateResponseEntityExistsOrFail(HttpResponse response, String resource) {
+    if (response.getEntity() == null) {
+      ExceptionUtil.throwRuntimeExceptionAndLog(
+          logger,
+          String.format(
+              "Error accessing response body for resource %s; status %s",
+              resource, response.getStatusLine().toString()));
+    }
   }
 
   private static boolean isResponseValidInternal(HttpResponse response, boolean checkEntity) {

--- a/server/src/test/java/com/google/fhir/proxy/BearerAuthorizationInterceptorTest.java
+++ b/server/src/test/java/com/google/fhir/proxy/BearerAuthorizationInterceptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Google LLC
+ * Copyright 2021-2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,7 @@ import java.util.Base64;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.CapabilityStatement;
 import org.junit.Before;
@@ -236,6 +237,18 @@ public class BearerAuthorizationInterceptorTest {
     authorizeRequestCommonSetUp(testPatientIdSearch);
     testInstance.authorizeRequest(requestMock);
     String replaced = testPatientIdSearch.replaceAll(FHIR_STORE, BASE_URL);
+    assertThat(replaced, equalTo(writerStub.toString()));
+  }
+
+  @Test
+  public void authorizeRequestTestResourceErrorResponse() throws IOException {
+    URL errorUrl = Resources.getResource("error_operation_outcome.json");
+    String errorResponse = Resources.toString(errorUrl, StandardCharsets.UTF_8);
+    authorizeRequestCommonSetUp(errorResponse);
+    when(fhirResponseMock.getStatusLine().getStatusCode())
+        .thenReturn(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+    testInstance.authorizeRequest(requestMock);
+    String replaced = errorResponse.replaceAll(FHIR_STORE, BASE_URL);
     assertThat(replaced, equalTo(writerStub.toString()));
   }
 

--- a/server/src/test/resources/error_operation_outcome.json
+++ b/server/src/test/resources/error_operation_outcome.json
@@ -1,0 +1,18 @@
+{
+  "resourceType": "OperationOutcome",
+  "meta": {
+    "profile": ["https://healthcare.googleapis.com/v1/projects/fhir-sdk/locations/us/datasets/synthea-sample-data/fhirStores/gcs-data/fhir/StructureDefinition/Spine-OperationOutcome-1"]
+  },
+  "issue": [{
+    "severity": "error",
+    "code": "exception",
+    "details": {
+      "coding": [{
+        "system": "https://healthcare.googleapis.com/v1/projects/fhir-sdk/locations/us/datasets/synthea-sample-data/fhirStores/gcs-data/fhir/ValueSet/Spine-ErrorOrWarningCode-1",
+        "code": "INTERNAL_SERVER_ERROR",
+        "display": "Internal server error"
+      }]
+    },
+    "diagnostics": "Any further internal debug details i.e. stack trace details etc."
+  }]
+}


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->

## Description of what I changed
Instead of throwing a custom error response when a non-200 response is received from FHIR resource server, we will now relay the error response received from the FHIR server as is.

Fixes #42 

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test


<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Ran the server along with the HAPI FHIR server and Keycloak. For the same URL which results in an error response from the FHIR resource server, compared the responses before and after the changes. The change results in providing the same error response that is received from the FHIR server.

The response before the changes for the url 

`curl -X GET -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-H "Content-Type: application/json; charset=utf-8" \
'http://localhost:8081/Patient/12'`

was 
`{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"processing","diagnostics":"Error accessing resource Patient/12; status HTTP/1.1 404 "}]}`

After the required changes the response is 

`{
  "resourceType": "OperationOutcome",
  "text": {
    "status": "generated",
    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h1>Operation Outcome</h1><table border=\"0\"><tr><td style=\"font-weight: bold;\">ERROR</td><td>[]</td><td><pre>HAPI-1996: Resource Patient/12 is not known</pre></td>\n\t\t\t</tr>\n\t\t</table>\n\t</div>"
  },
  "issue": [ {
    "severity": "error",
    "code": "processing",
    "diagnostics": "HAPI-1996: Resource Patient/12 is not known"
  } ]
}`



## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [x] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
