### PR TITLE
Fixed logging issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,10 @@
     <root.basedir>${project.basedir}</root.basedir>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <slf4j.version>2.0.6</slf4j.version>
     <!-- Check this for why we are not using a higher version for now:
-      https://www.slf4j.org/codes.html#StaticLoggerBinder -->
+      https://www.slf4j.org/codes.html#StaticLoggerBinder
+      The root cause is that we are using an older version of Spring. -->
+    <slf4j.version>1.7.36</slf4j.version>
     <logback.version>1.2.11</logback.version>
     <license-maven-plugin.version>4.1</license-maven-plugin.version>
   </properties>


### PR DESCRIPTION
<!-- This is based on openmrs-cord PR template. -->

## Description of what I changed
I realized that when I run the gateway server, it does not print log messages anymore. The root cause was PR #62 and in particular `slf4j.version` update.

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
<!--- If your PR is related to an issue , please mention it here. -->
<!--- It is generally a good practice to first file an issue with enough
  context and reference it in the PR, but if you don't have that, please remove
  this section. -->

## E2E test

<!-- There are different scenarios for using the tools in this repo; please
  help your reviewers by describing how you have e2e tested your change. -->

TESTED:

Ran the server and checked that the log message are printed.

## Checklist: I completed these to help reviewers :)

<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->

- [x] I have read and will follow the [review process](https://github.com/GoogleCloudPlatform/openmrs-fhir-analytics/blob/master/doc/review_process.md).
- [x] I am familiar with Google Style Guides for the language I have coded in.

  No? Please take some time and review [Java](https://google.github.io/styleguide/javaguide.html) and [Python](https://google.github.io/styleguide/pyguide.html) style guides.

- [x] My IDE is configured to follow the Google [**code styles**](https://google.github.io/styleguide/).

  No? Unsure? -> [configure your IDE](https://github.com/google/google-java-format).

- [ ] I have **added tests** to cover my changes. (If you refactored existing code that was well tested you do not have to add tests)
- [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
- [x] All new and existing **tests passed**.
- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
